### PR TITLE
[wip] hide side app drawer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+xcuserdata/
+*.xcuserdatad/

--- a/Focus for YouTube/ViewController.swift
+++ b/Focus for YouTube/ViewController.swift
@@ -44,7 +44,8 @@ var blockableElements: [BlockableElement] = [
     BlockableElement(withName: "Masthead Buttons", andRule: BlockerRule(selector: "div#buttons"), isBlockedByDefault: false),
     BlockableElement(withName: "Details and Likes Bar", andRule: BlockerRule(selector: "div#info"), isBlockedByDefault: false),
     BlockableElement(withName: "Description", andRule: BlockerRule(selector: "ytd-expander.ytd-video-secondary-info-renderer"), isBlockedByDefault: false),
-    BlockableElement(withName: "Thumbnail Images", andRule: BlockerRule(triggers: [.urlFilter: "https?://www.youtube.com.*", .resourceType: ["fetch"]], actionType: .CSSDisplayNone, selector: "#thumbnail #img"), isBlockedByDefault: false)
+    BlockableElement(withName: "Thumbnail Images", andRule: BlockerRule(triggers: [.urlFilter: "https?://www.youtube.com.*", .resourceType: ["fetch"]], actionType: .CSSDisplayNone, selector: "#thumbnail #img"), isBlockedByDefault: false),
+    BlockableElement(withName: "Guide Button", andRule: BlockerRule(selector: "#guide-button"), isBlockedByDefault: false)
 ]
 
 class ViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate, DOMElementCellDelegate {


### PR DESCRIPTION
I wanted to hide the whole expandable app drawer.

I started with the guide button.

Problem is - if someone hides the guide button after the drawer is open, the drawer exists and can't be closed.

Ideally we set the drawer state to !open if the user has hidden the guide button.
